### PR TITLE
Minor typo change from similary -> similarity.

### DIFF
--- a/website/pages/libraries.html
+++ b/website/pages/libraries.html
@@ -16,7 +16,7 @@
             <div class="card-body">
                 <h6 class="card-title">Mass-ts</h6>
                 <p class="card-text">
-                    Mueen's Algorithm For Similary Search (MASS) algorithms implemented in Python.
+                    Mueen's Algorithm For Similarity Search (MASS) algorithms implemented in Python.
                 </p>
                 <p class="card-text">
                     Links:


### PR DESCRIPTION
Correct small typo in MASS acronym on libraries page.